### PR TITLE
[IMP] auto upload upon save

### DIFF
--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -12,6 +12,18 @@ local function create_autocmd()
       M.recent_command = nil
     end,
   })
+
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    group = augroup,
+    desc = "Auto upload current file upon save",
+    buffer = vim.api.nvim_get_current_buf(),
+    callback = function()
+      local config = require("transfer.config")
+      if config.options.upload_on_save then
+        vim.api.nvim_command("TransferUpload")
+      end
+    end,
+  })
 end
 
 M.setup = function()


### PR DESCRIPTION
This improvement provides you to upload your current buffer upon saving it. To use it, you must use `upload_on_save = true` in your plugin configuration.