### PR TITLE
[IMP] replace backslash with forward slash in case of using windows version

### DIFF
--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -12,6 +12,18 @@ local function create_autocmd()
       M.recent_command = nil
     end,
   })
+
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    group = augroup,
+    desc = "Auto upload current file upon save",
+    buffer = vim.api.nvim_get_current_buf(),
+    callback = function()
+      local config = require("transfer.config")
+      if config.options.upload_on_save then
+        vim.api.nvim_command("TransferUpload")
+      end
+    end,
+  })
 end
 
 M.setup = function()

--- a/lua/transfer/transfer.lua
+++ b/lua/transfer/transfer.lua
@@ -65,6 +65,7 @@ local function build_scp_path(deployment, remote_file)
   if deployment.username then
     remote_path = remote_path .. deployment.username .. "@"
   end
+  remote_file = string.gsub(remote_file, "\\", "/")
   remote_path = remote_path .. deployment.host
   remote_path = remote_path .. "/" .. remote_file
   return remote_path


### PR DESCRIPTION
It has been tested on Windows without any problems.