### PR TITLE
[IMP] ssh password option and prompt + notification option

### DIFF
--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -12,6 +12,18 @@ local function create_autocmd()
       M.recent_command = nil
     end,
   })
+
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    group = augroup,
+    desc = "Auto upload current file upon save",
+    buffer = vim.api.nvim_get_current_buf(),
+    callback = function()
+      local config = require("transfer.config")
+      if config.options.upload_on_save then
+        vim.api.nvim_command("TransferUpload")
+      end
+    end,
+  })
 end
 
 M.setup = function()

--- a/lua/transfer/transfer.lua
+++ b/lua/transfer/transfer.lua
@@ -65,6 +65,7 @@ local function build_scp_path(deployment, remote_file)
   if deployment.username then
     remote_path = remote_path .. deployment.username .. "@"
   end
+  remote_file = string.gsub(remote_file, "\\", "/")
   remote_path = remote_path .. deployment.host
   remote_path = remote_path .. "/" .. remote_file
   return remote_path


### PR DESCRIPTION
This commit includes two different thing, I cannot distinguish them for now so I've just committed it.

First, you can use this plugin with plain ssh password, or with a password prompt. You can use something like `password = "pass123"` in your deployment.lua. If there is no password set, a password prompt welcomes you and wants you to enter it. Then, it's done.

Second, I made a notification option and made it as table, because maybe it can be improved more afterwards. If you use `notification = { use_cwd = true }` in your plugin config, notification descriptions which show the file path will be trimmed according to current working directory, so it occupies a small space on your screen.