### PR TITLE
feat: enable password-based SSH/rsync operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ https://github.com/coffebar/transfer.nvim/assets/3100053/32cb642a-9040-47dd-a661
 ## Not tested or not working:
 
 - Windows paths;
-- SSH Auth that is not passwordless.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ return {
   ["example_name"] = {
     host = "myhost",
     username = "web", -- optional
+    password = true, -- optional [string|true will prompt for password each time]
     mappings = {
       {
         ["local"] = "live", -- path relative to project root


### PR DESCRIPTION
## Overview of Changes

This PR adds support for SSH password authentication. Users can now specify a plaintext password in their `.nvim/deployment.lua` config, or set `password = true` to be prompted for their password interactively before each upload, download, sync, or diff operation. The implementation uses `sshpass` to enable password-based SSH/rsync commands, while preserving compatibility with existing workflows.

## The Case for SSH Password Auth

**_I know previous PRs have been denied due to philosophical reasons, but wait hear me out!_**

While key-based authentication is preferred for security (obviously!), there are legitimate scenarios in software development where password authentication is necessary or more practical:

- CI/CD pipelines running on ephemeral hosts where key management is impractical.
- Legacy systems or embedded devices that only support password authentication.
- Vendor-controlled or collaborative environments with restricted access.
- Rapid prototyping, disposable VMs, or containers where password auth is simpler.
- Educational setups where simplicity is prioritized.
- Local development servers (`localhost`) or remote hosts with limited configuration options.

Supporting password authentication allows `transfer.nvim` to be used in a wider range of real-world development workflows.

## Why This Matters

- IMHO `transfer.nvim` is the most complete and useful SSH/rsync plugin for Neovim, but password authentication has been a missing feature which had previously prevented me from using it. So now I've added the feature set which allows me to use your awesome plugin as a daily driver in my work.
- Adding this support makes the plugin more versatile and accessible to a broader range of users and workflows without taking **anything** away from the majority of people who are able to use publickey auth for their work. In fact I require both, which is what makes this plugin so great.

## Sample Deployment Config

```lua
-- .nvim/deployment.lua
return {
  ["example_name"] = {
    host = "myhost",
    username = "web", -- optional
    password = true, -- optional [string|true will prompt for password each time]
    mappings = {
      {
        ["local"] = "live", -- path relative to project root
        ["remote"] = "/var/www/example.com", -- absolute path or relative to user home
      },
      {
        ["local"] = "test",
        ["remote"] = "/var/www/test.example.com",
      },
    },
  },
}
```