### PR TITLE
feat: upload on save per project/host/mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ https://github.com/coffebar/transfer.nvim/assets/3100053/32cb642a-9040-47dd-a661
 ## Not tested or not working:
 
 - Windows paths;
-- SSH Auth that is not passwordless.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ return {
   ["example_name"] = {
     host = "myhost",
     username = "web", -- optional
+    password = true, -- optional [string|true will prompt for password each time]
     mappings = {
       {
         ["local"] = "live", -- path relative to project root

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ return {
       "live/src/", -- local path relative to project root
       "test/src/",
     },
+    upload_on_save = false
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,37 @@ Host server2
   ...
 ```
 
+Finally, you need to be sure to login to the host interactively at least one time and accept the host fingerprint, to ensure the remote host fingerprint exists in your local `~/.ssh/known_hosts` file, otherwise the remote operations will appear to hang and timeout while your local client waits for you to accept the new remote host fingerprint in the background.
+
+If you are using an ephemeral remote host for development purposes, where you expect the remote host fingerprint to change regularly, (AND YOU ARE ABSOLUTELY SURE YOU TRUST THE REMOTE!) you can add the following items to your `~/.ssh/config` file for a specific remote host:
+
+```ssh
+Host myhost
+  ...
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+```
+
+**Password-based Authentication**
+
+The `sshpass` utility is a required dependency when using password-based authentication. Be sure `sshpass` is installed and available in your `PATH`.
+
+There are three possible values for the `password` item in a deployment/mapping table:
+
+- `password=true`: you will be prompted to enter a password for each operation.
+- `password="mypassword"`: the password will be set automatically with `sshpass` for each operation.
+- `password=""`: an empty password will be used for each operation.
+
+Example `-/.ssh/config` for password-based auth:
+
+```ssh
+Host myhost
+  HostName 127.0.0.1
+  User web
+  PubkeyAuthentication=no
+  PreferredAuthentications=password
+```
+
 ## Suggested mappings
 
 ### Neo-tree

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ return {
   ["example_name"] = {
     host = "myhost",
     username = "web", -- optional
+    password = true, -- optional [string|true will prompt for password each time]
     mappings = {
       {
         ["local"] = "live", -- path relative to project root
@@ -54,6 +55,7 @@ return {
       "live/src/", -- local path relative to project root
       "test/src/",
     },
+    upload_on_save = false
   },
 }
 ```
@@ -152,6 +154,43 @@ require("which-key").add({
 })
 ```
 
+## Snacks.explorer (with lazy.nvim)
+
+```lua
+return {
+  "coffebar/transfer.nvim",
+  lazy = true,
+  cmd = { "TransferInit", "DiffRemote", "TransferUpload", "TransferDownload", "TransferDirDiff", "TransferRepeat" },
+  opts = {},
+  dependencies = { 'folke/snacks.nvim' },
+  specs = {
+    {
+      'folke/snacks.nvim',
+      opts = {
+        picker = {
+          actions = {
+            transfer_up = function(_, item)
+              vim.cmd.TransferUpload(item.file)
+            end,
+            transfer_down = function(_, item)
+              vim.cmd.TransferDownload(item.file)
+            end,
+          },
+          win = {
+            list = {
+              keys = {
+                ['tu'] = 'transfer_up',
+                ['td'] = 'transfer_down',
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Recommended to use with
 
 - [rcarriga/nvim-notify](https://github.com/rcarriga/nvim-notify) - animated popup notifications.
@@ -173,7 +212,6 @@ https://github.com/coffebar/transfer.nvim/assets/3100053/32cb642a-9040-47dd-a661
 ## Not tested or not working:
 
 - Windows paths;
-- SSH Auth that is not passwordless.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -175,12 +175,20 @@ return {
             transfer_down = function(_, item)
               vim.cmd.TransferDownload(item.file)
             end,
+            transfer_diff = function(_, item)
+              if item.dir then
+                vim.cmd.TransferDirDiff(item.file)
+              else
+                vim.cmd.DiffRemote(item.file)
+              end
+            end,
           },
           win = {
             list = {
               keys = {
                 ['tu'] = 'transfer_up',
                 ['td'] = 'transfer_down',
+                ['tD'] = 'transfer_diff',
               }
             }
           }

--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -53,8 +53,14 @@ M.setup = function()
   end, { nargs = 0 })
 
   -- DiffRemote - open a diff view with the remote file
-  vim.api.nvim_create_user_command("DiffRemote", function()
-    local local_path = vim.fn.expand("%:p")
+  vim.api.nvim_create_user_command("DiffRemote", function(opts)
+    local local_path
+    if opts ~= nil and opts.args then
+      local_path = opts.args
+    end
+    if local_path == nil or local_path == "" then
+      local_path = vim.fn.expand("%:p")
+    end
     local remote_path = require("transfer.transfer").remote_scp_path(local_path)
     if remote_path == nil then
       return
@@ -73,7 +79,7 @@ M.setup = function()
     end
 
     vim.api.nvim_command("silent! diffsplit " .. remote_path)
-  end, { nargs = 0 })
+  end, { nargs = "?" })
 
   -- TransferUpload - upload the given file or directory
   vim.api.nvim_create_user_command("TransferUpload", function(opts)

--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 M.recent_command = nil
-M.saving = {}
 
 local function create_autocmd()
   local augroup = vim.api.nvim_create_augroup("TransferNvim", { clear = true })
@@ -18,19 +17,7 @@ local function create_autocmd()
     group = augroup,
     desc = "Upload on Save",
     callback = function(args)
-      if M.saving[args.file] then
-        return
-      end
-      M.saving[args.file] = true
-      local plugin = require"transfer.transfer"
-      local _, deployment = plugin.remote_scp_path(args.file, true)
-      if deployment and deployment.upload_on_save then
-        plugin.upload_file(args.file, function()
-            M.saving[args.file] = nil
-        end)
-      else
-        M.saving[args.file] = nil
-      end
+      require"transfer.transfer".upload_on_save(args.file)
     end,
   })
 end

--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.recent_command = nil
+M.saving = {}
 
 local function create_autocmd()
   local augroup = vim.api.nvim_create_augroup("TransferNvim", { clear = true })
@@ -10,6 +11,26 @@ local function create_autocmd()
     desc = "Clear recent command after changing directory",
     callback = function()
       M.recent_command = nil
+    end,
+  })
+
+  vim.api.nvim_create_autocmd("BufWritePost", {
+    group = augroup,
+    desc = "Upload on Save",
+    callback = function(args)
+      if M.saving[args.file] then
+        return
+      end
+      M.saving[args.file] = true
+      local plugin = require"transfer.transfer"
+      local _, deployment = plugin.remote_scp_path(args.file, true)
+      if deployment and deployment.upload_on_save then
+        plugin.upload_file(args.file, function()
+            M.saving[args.file] = nil
+        end)
+      else
+        M.saving[args.file] = nil
+      end
     end,
   })
 end

--- a/lua/transfer/transfer.lua
+++ b/lua/transfer/transfer.lua
@@ -77,7 +77,7 @@ end
 -- @return table
 local function build_command(deployment, command, callback)
   -- @param password string?
-  local function build(password)
+  local function _build(password)
     local _command = {}
     if password and password ~= '' then
       _command = { "sshpass", "-p", password }
@@ -89,10 +89,22 @@ local function build_command(deployment, command, callback)
   end
 
   if deployment.password then
+    if vim.fn.executable('sshpass') ~= 1 then
+      vim.notify('Password-based authentication requires `sshpass`', vim.log.levels.ERROR)
+      return
+    end
     if deployment.password == true then
-      vim.ui.input({prompt="Password for "..deployment.username.."@"..deployment.host}, build)
+      vim.ui.input({prompt="Password for "..deployment.host}, function(input)
+        if not input or input == '' then
+          vim.schedule(function()
+            vim.notify('No password was entered, cancelling', vim.log.levels.ERROR)
+          end)
+        else
+          _build(input)
+        end
+      end)
     else
-      build(deployment.password)
+      _build(deployment.password)
     end
   else
     vim.schedule_wrap(callback)(command)
@@ -128,7 +140,7 @@ end
 
 -- get the remote path for scp
 -- @param local_path string
--- @return string
+-- @return string, table
 function M.remote_scp_path(local_path)
   local cwd = vim.loop.cwd()
   local config_file = cwd .. "/.nvim/deployment.lua"
@@ -240,20 +252,22 @@ function M.upload_file(local_path)
   if remote_path == nil then
     return
   end
-  local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
-  local stderr = {}
-  local notification = vim.notify(local_short, vim.log.levels.INFO, {
-    title = "Uploading file...",
-    timeout = 0,
-    icon = "󱕌 ",
-  })
-  local notification_id
-  if type(notification) == "table" and notification.id then
-    notification_id = notification.id
-  elseif type(notification) == "number" then
-    notification_id = notification
-  end
+
   build_command(deployment, { "scp", local_path, remote_path }, function(command)
+    local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
+    local notification = vim.notify(local_short, vim.log.levels.INFO, {
+      title = "Uploading file...",
+      timeout = 0,
+      icon = "󱕌 ",
+    })
+    local notification_id
+    if type(notification) == "table" and notification.id then
+      notification_id = notification.id
+    elseif type(notification) == "number" then
+      notification_id = notification
+    end
+
+    local stderr = {}
     vim.fn.jobstart(command, {
       on_stderr = function(_, data, _)
         if data == nil or #data == 0 then
@@ -296,21 +310,22 @@ function M.download_file(local_path)
   if remote_path == nil then
     return
   end
-  local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
 
-  local notification = vim.notify(local_short, vim.log.levels.INFO, {
-    title = "Downloading file...",
-    timeout = 0,
-    icon = "󱕉 ",
-  })
-  local notification_id
-  if type(notification) == "table" and notification.id then
-    notification_id = notification.id
-  elseif type(notification) == "number" then
-    notification_id = notification
-  end
-  local stderr = {}
   build_command(deployment, { "scp", remote_path, local_path }, function(command)
+    local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
+    local notification = vim.notify(local_short, vim.log.levels.INFO, {
+      title = "Downloading file...",
+      timeout = 0,
+      icon = "󱕉 ",
+    })
+    local notification_id
+    if type(notification) == "table" and notification.id then
+      notification_id = notification.id
+    elseif type(notification) == "number" then
+      notification_id = notification
+    end
+
+    local stderr = {}
     vim.fn.jobstart(command, {
       on_stderr = function(_, data, _)
         if data == nil or #data == 0 then
@@ -393,20 +408,21 @@ function M.sync_dir(dir, upload)
     vim.list_extend(cmd, { remote_path .. "/", dir .. "/" })
   end
 
-  local notification = vim.notify("rsync: " .. remote_path, vim.log.levels.INFO, {
-    title = "Sync started...",
-    icon = " ",
-    timeout = 5000,
-  })
-  local notification_id
-  if type(notification) == "table" and notification.id then
-    notification_id = notification.id
-  elseif type(notification) == "number" then
-    notification_id = notification
-  end
-  local output = {}
-  local stderr = {}
   build_command(deployment, cmd, function(command)
+    local notification = vim.notify("rsync: " .. remote_path, vim.log.levels.INFO, {
+      title = "Sync started...",
+      icon = " ",
+      timeout = 5000,
+    })
+    local notification_id
+    if type(notification) == "table" and notification.id then
+      notification_id = notification.id
+    elseif type(notification) == "number" then
+      notification_id = notification
+    end
+
+    local output = {}
+    local stderr = {}
     vim.fn.jobstart(command, {
       on_stderr = function(_, data, _)
         if data == nil or #data == 0 then
@@ -485,25 +501,25 @@ function M.show_dir_diff(dir)
       end
     end
   end
-
-  local lines = { " " .. table.concat(cmd, " ") }
   vim.list_extend(cmd, { dir .. "/", remote_path .. "/" })
 
-  local notification = vim.notify("rsync -rlzi --dry-run --checksum --delete", vim.log.levels.INFO, {
-    title = "Diff started...",
-    icon = " ",
-    timeout = 3500,
-  })
-  local notification_id
-  if type(notification) == "table" and notification.id then
-    notification_id = notification.id
-  elseif type(notification) == "number" then
-    notification_id = notification
-  end
-  vim.list_extend(lines, { normalize_local_path(dir), remote_path, "------" })
-  local output = {}
-  local stderr = {}
+  local lines = { " " .. table.concat(cmd, " "), normalize_local_path(dir), remote_path, "------" }
+
   build_command(deployment, cmd, function(command)
+    local notification = vim.notify("rsync -rlzi --dry-run --checksum --delete", vim.log.levels.INFO, {
+      title = "Diff started...",
+      icon = " ",
+      timeout = 3500,
+    })
+    local notification_id
+    if type(notification) == "table" and notification.id then
+      notification_id = notification.id
+    elseif type(notification) == "number" then
+      notification_id = notification
+    end
+
+    local output = {}
+    local stderr = {}
     vim.fn.jobstart(command, {
       on_stderr = function(_, data, _)
         if data == nil or #data == 0 then

--- a/lua/transfer/transfer.lua
+++ b/lua/transfer/transfer.lua
@@ -70,6 +70,35 @@ local function build_scp_path(deployment, remote_file)
   return remote_path
 end
 
+-- build command with sshpass if needed
+-- @param deployment table
+-- @param command table
+-- @param callback function
+-- @return table
+local function build_command(deployment, command, callback)
+  -- @param password string?
+  local function build(password)
+    local _command = {}
+    if password and password ~= '' then
+      _command = { "sshpass", "-p", password }
+      vim.list_extend(_command, command)
+    else
+      _command = command
+    end
+    vim.schedule_wrap(callback)(_command)
+  end
+
+  if deployment.password then
+    if deployment.password == true then
+      vim.ui.input({prompt="Password for "..deployment.username.."@"..deployment.host}, build)
+    else
+      build(deployment.password)
+    end
+  else
+    vim.schedule_wrap(callback)(command)
+  end
+end
+
 -- get the excluded paths for the given directory
 -- @param deployment table
 -- @param dir string
@@ -99,21 +128,24 @@ end
 
 -- get the remote path for scp
 -- @param local_path string
--- @return string
-function M.remote_scp_path(local_path)
+-- @param quiet? boolean
+-- @return string|nil, table|nil
+function M.remote_scp_path(local_path, quiet)
   local cwd = vim.loop.cwd()
   local config_file = cwd .. "/.nvim/deployment.lua"
   if vim.fn.filereadable(config_file) ~= 1 then
-    vim.notify(
-      "No deployment config found in \n" .. config_file .. "\n\nRun `:TransferInit` to create it",
-      vim.log.levels.WARN,
-      {
-        title = "Transfer.nvim",
-        icon = " ",
-        timeout = 4000,
-      }
-    )
-    return nil
+    if not quiet then
+      vim.notify(
+        "No deployment config found in \n" .. config_file .. "\n\nRun `:TransferInit` to create it",
+        vim.log.levels.WARN,
+        {
+          title = "Transfer.nvim",
+          icon = " ",
+          timeout = 4000,
+        }
+      )
+    end
+    return nil,nil
   end
   local deployment_conf = dofile(config_file)
   -- remove cwd from local file path
@@ -175,12 +207,14 @@ function M.remote_scp_path(local_path)
   if skip_reason == nil then
     skip_reason = "File '" .. local_path .. "'\nis not mapped in deployment config"
   end
-  vim.notify(skip_reason, vim.log.levels.ERROR, {
-    title = "No mappings found",
-    icon = " ",
-    timeout = 4000,
-  })
-  return nil
+  if not quiet then
+    vim.notify(skip_reason, vim.log.levels.ERROR, {
+      title = "No mappings found",
+      icon = " ",
+      timeout = 4000,
+    })
+  end
+  return nil, nil
 end
 
 -- get the remote path for rsync
@@ -200,15 +234,19 @@ end
 
 -- upload the given file
 -- @param local_path string
+-- @param callback? function
 -- @return void
-function M.upload_file(local_path)
+function M.upload_file(local_path, callback)
   if local_path == nil then
     local_path = vim.fn.expand("%:p")
   else
     local_path = vim.fn.fnamemodify(local_path, ":p")
   end
-  local remote_path = M.remote_scp_path(local_path)
+  local remote_path, deployment = M.remote_scp_path(local_path)
   if remote_path == nil then
+    if callback then
+      vim.schedule(callback)
+    end
     return
   end
   local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
@@ -224,33 +262,38 @@ function M.upload_file(local_path)
   elseif type(notification) == "number" then
     notification_id = notification
   end
-  vim.fn.jobstart({ "scp", local_path, remote_path }, {
-    on_stderr = function(_, data, _)
-      if data == nil or #data == 0 then
-        return
-      end
-      vim.list_extend(stderr, data)
-    end,
-    on_exit = function(_, code, _)
-      if code == 0 then
-        vim.notify(remote_path, vim.log.levels.INFO, {
-          id = notification_id,
-          title = "File uploaded",
-          icon = "",
-          timeout = 3000,
-          replace = notification_id,
-        })
-      else
-        vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
-          id = notification_id,
-          title = "Error uploading file",
-          timeout = 4000,
-          replace = notification_id,
-          icon = " ",
-        })
-      end
-    end,
-  })
+  build_command(deployment, { "scp", local_path, remote_path }, function(command)
+    vim.fn.jobstart(command, {
+      on_stderr = function(_, data, _)
+        if data == nil or #data == 0 then
+          return
+        end
+        vim.list_extend(stderr, data)
+      end,
+      on_exit = function(_, code, _)
+        if code == 0 then
+          vim.notify(remote_path, vim.log.levels.INFO, {
+            id = notification_id,
+            title = "File uploaded",
+            icon = "",
+            timeout = 3000,
+            replace = notification_id,
+          })
+        else
+          vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
+            id = notification_id,
+            title = "Error uploading file",
+            timeout = 4000,
+            replace = notification_id,
+            icon = " ",
+          })
+        end
+        if callback then
+          vim.schedule(callback)
+        end
+      end,
+    })
+  end)
 end
 
 -- Replace local file with remote copy
@@ -261,7 +304,7 @@ function M.download_file(local_path)
   else
     local_path = vim.fn.fnamemodify(local_path, ":p")
   end
-  local remote_path = M.remote_scp_path(local_path)
+  local remote_path, deployment = M.remote_scp_path(local_path)
   if remote_path == nil then
     return
   end
@@ -279,38 +322,40 @@ function M.download_file(local_path)
     notification_id = notification
   end
   local stderr = {}
-  vim.fn.jobstart({ "scp", remote_path, local_path }, {
-    on_stderr = function(_, data, _)
-      if data == nil or #data == 0 then
-        return
-      end
-      vim.list_extend(stderr, data)
-    end,
-    on_exit = function(_, code, _)
-      if code == 0 then
-        vim.notify(remote_path, vim.log.levels.INFO, {
-          id = notification_id,
-          title = "Remote file downloaded",
-          icon = "",
-          timeout = 1000,
-          replace = notification_id,
-        })
-        -- reload buffer for the downloaded file
-        local bufnr = vim.fn.bufnr(local_path)
-        if bufnr ~= -1 then
-          reload_buffer(bufnr)
+  build_command(deployment, { "scp", remote_path, local_path }, function(command)
+    vim.fn.jobstart(command, {
+      on_stderr = function(_, data, _)
+        if data == nil or #data == 0 then
+          return
         end
-      else
-        vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
-          id = notification_id,
-          title = "Error downloading file",
-          icon = " ",
-          timeout = 4000,
-          replace = notification_id,
-        })
-      end
-    end,
-  })
+        vim.list_extend(stderr, data)
+      end,
+      on_exit = function(_, code, _)
+        if code == 0 then
+          vim.notify(remote_path, vim.log.levels.INFO, {
+            id = notification_id,
+            title = "Remote file downloaded",
+            icon = "",
+            timeout = 1000,
+            replace = notification_id,
+          })
+          -- reload buffer for the downloaded file
+          local bufnr = vim.fn.bufnr(local_path)
+          if bufnr ~= -1 then
+            reload_buffer(bufnr)
+          end
+        else
+          vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
+            id = notification_id,
+            title = "Error downloading file",
+            icon = " ",
+            timeout = 4000,
+            replace = notification_id,
+          })
+        end
+      end,
+    })
+  end)
 end
 
 -- Some rsync params can be functions
@@ -373,59 +418,61 @@ function M.sync_dir(dir, upload)
   end
   local output = {}
   local stderr = {}
-  vim.fn.jobstart(cmd, {
-    on_stderr = function(_, data, _)
-      if data == nil or #data == 0 then
-        return
-      end
-      vim.list_extend(stderr, data)
-    end,
-    on_stdout = function(_, data, _)
-      for _, line in pairs(data) do
-        if line ~= "" then
-          table.insert(output, line)
+  build_command(deployment, cmd, function(command)
+    vim.fn.jobstart(command, {
+      on_stderr = function(_, data, _)
+        if data == nil or #data == 0 then
+          return
         end
-      end
-    end,
-    on_exit = function(_, code, _)
-      if code ~= 0 then
-        vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
-          id = notification_id,
-          timeout = 10000,
-          title = "Error running rsync",
-          icon = " ",
-          replace = notification_id,
-        })
-        return
-      end
-
-      if not upload then
-        local filetype = vim.api.nvim_buf_get_option(0, "filetype")
-        if filetype == "neo-tree" then
-          reload_buffer(0)
-        end
-        -- reload all buffers in the synced directory
-        local buffers = vim.api.nvim_list_bufs()
-        for _, bufnr in pairs(buffers) do
-          local bufname = vim.api.nvim_buf_get_name(bufnr)
-          if bufname ~= "" and bufname:find(dir, 1, true) then
-            reload_buffer(bufnr)
+        vim.list_extend(stderr, data)
+      end,
+      on_stdout = function(_, data, _)
+        for _, line in pairs(data) do
+          if line ~= "" then
+            table.insert(output, line)
           end
         end
-      end
+      end,
+      on_exit = function(_, code, _)
+        if code ~= 0 then
+          vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
+            id = notification_id,
+            timeout = 10000,
+            title = "Error running rsync",
+            icon = " ",
+            replace = notification_id,
+          })
+          return
+        end
 
-      if #output == 0 then
-        output = { "No differences found" }
-      end
-      vim.notify(table.concat(output, "\n"), vim.log.levels.INFO, {
-        id = notification_id,
-        timeout = 3000,
-        title = "Sync completed",
-        icon = " ",
-        replace = notification_id,
-      })
-    end,
-  })
+        if not upload then
+          local filetype = vim.api.nvim_buf_get_option(0, "filetype")
+          if filetype == "neo-tree" then
+            reload_buffer(0)
+          end
+          -- reload all buffers in the synced directory
+          local buffers = vim.api.nvim_list_bufs()
+          for _, bufnr in pairs(buffers) do
+            local bufname = vim.api.nvim_buf_get_name(bufnr)
+            if bufname ~= "" and bufname:find(dir, 1, true) then
+              reload_buffer(bufnr)
+            end
+          end
+        end
+
+        if #output == 0 then
+          output = { "No differences found" }
+        end
+        vim.notify(table.concat(output, "\n"), vim.log.levels.INFO, {
+          id = notification_id,
+          timeout = 3000,
+          title = "Sync completed",
+          icon = " ",
+          replace = notification_id,
+        })
+      end,
+    })
+  end)
 end
 
 function M.show_dir_diff(dir)
@@ -468,42 +515,44 @@ function M.show_dir_diff(dir)
   vim.list_extend(lines, { normalize_local_path(dir), remote_path, "------" })
   local output = {}
   local stderr = {}
-  vim.fn.jobstart(cmd, {
-    on_stderr = function(_, data, _)
-      if data == nil or #data == 0 then
-        return
-      end
-      vim.list_extend(stderr, data)
-    end,
-    on_stdout = function(_, data, _)
-      for _, line in pairs(data) do
-        if line ~= "" then
-          line = line:gsub("^deleting ", " ")
-          table.insert(output, line)
+  build_command(deployment, cmd, function(command)
+    vim.fn.jobstart(command, {
+      on_stderr = function(_, data, _)
+        if data == nil or #data == 0 then
+          return
         end
-      end
-    end,
-    on_exit = function(_, code, _)
-      if code ~= 0 then
-        vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
-          id = notification_id,
-          timeout = 10000,
-          title = "Error running rsync",
-          icon = " ",
-          replace = notification_id,
-        })
-        return
-      end
-      if #output == 0 then
-        table.insert(lines, " No differences found")
-      else
-        vim.list_extend(lines, output)
-      end
-      -- show quickfix list
-      vim.fn.setqflist({}, "r", { title = "Diff: " .. dir, lines = lines })
-      vim.api.nvim_command("copen")
-    end,
-  })
+        vim.list_extend(stderr, data)
+      end,
+      on_stdout = function(_, data, _)
+        for _, line in pairs(data) do
+          if line ~= "" then
+            line = line:gsub("^deleting ", " ")
+            table.insert(output, line)
+          end
+        end
+      end,
+      on_exit = function(_, code, _)
+        if code ~= 0 then
+          vim.notify(table.concat(stderr, "\n"), vim.log.levels.ERROR, {
+            id = notification_id,
+            timeout = 10000,
+            title = "Error running rsync",
+            icon = " ",
+            replace = notification_id,
+          })
+          return
+        end
+        if #output == 0 then
+          table.insert(lines, " No differences found")
+        else
+          vim.list_extend(lines, output)
+        end
+        -- show quickfix list
+        vim.fn.setqflist({}, "r", { title = "Diff: " .. dir, lines = lines })
+        vim.api.nvim_command("copen")
+      end,
+    })
+  end)
 end
 
 return M

--- a/lua/transfer/transfer.lua
+++ b/lua/transfer/transfer.lua
@@ -2,6 +2,8 @@ local config = require("transfer.config")
 
 local M = {}
 
+M._saving = {}
+
 -- reloads the buffer after a transfer
 -- refreshes the neo-tree if the buffer is a neo-tree
 -- @param bufnr number
@@ -76,38 +78,47 @@ end
 -- @param callback function
 -- @return table
 local function build_command(deployment, command, callback)
-  -- @param password string?
-  local function _build(password)
-    local _command = {}
-    if password and password ~= '' then
-      _command = { "sshpass", "-p", password }
-      vim.list_extend(_command, command)
-    else
-      _command = command
-    end
-    vim.schedule_wrap(callback)(_command)
+  if not deployment.password then
+    callback(command)
+    return
   end
 
-  if deployment.password then
-    if vim.fn.executable('sshpass') ~= 1 then
-      vim.notify('Password-based authentication requires `sshpass`', vim.log.levels.ERROR)
-      return
-    end
-    if deployment.password == true then
-      vim.ui.input({prompt="Password for "..deployment.host}, function(input)
-        if not input or input == '' then
-          vim.schedule(function()
-            vim.notify('No password was entered, cancelling', vim.log.levels.ERROR)
-          end)
-        else
-          _build(input)
-        end
-      end)
-    else
-      _build(deployment.password)
-    end
+  if deployment.password ~= true and type(deployment.password) ~= "string" then
+    vim.notify('Password must be either a `string` or `true`', vim.log.levels.ERROR)
+    callback(false)
+    return
+  end
+
+  if vim.fn.executable('sshpass') ~= 1 then
+    vim.notify('Password-based authentication requires `sshpass`', vim.log.levels.ERROR)
+    callback(false)
+    return
+  end
+
+  -- @param password string
+  local function _build(password)
+    local _command = { "sshpass", "-p", password }
+    vim.list_extend(_command, command)
+    callback(_command)
+  end
+
+  local function _prompt()
+    vim.ui.input({prompt="Password for "..deployment.host}, function(input)
+      if not input or input == '' then
+        vim.schedule(function()
+          vim.notify('No password was entered, cancelling', vim.log.levels.ERROR)
+          callback(false)
+        end)
+      else
+        _build(input)
+      end
+    end)
+  end
+
+  if type(deployment.password) == 'string' then
+    _build(deployment.password)
   else
-    vim.schedule_wrap(callback)(command)
+    vim.defer_fn(_prompt, 500) -- defer to ensure input gets focus
   end
 end
 
@@ -141,7 +152,7 @@ end
 -- get the remote path for scp
 -- @param local_path string
 -- @param quiet? boolean
--- @return string|nil, table|nil
+-- @return string, table
 function M.remote_scp_path(local_path, quiet)
   local cwd = vim.loop.cwd()
   local config_file = cwd .. "/.nvim/deployment.lua"
@@ -244,6 +255,37 @@ function M.remote_rsync_path(local_path)
   return remote_path, deployment
 end
 
+-- upload the given file on BufWritePost event
+-- @param local_path string
+-- @return void
+function M.upload_on_save(local_path)
+  if M._saving[local_path] then
+    return
+  end
+  M._saving[local_path] = true
+
+  local function _finished()
+    M._saving[local_path] = nil
+  end
+
+  local function _upload()
+    local _,deployment = M.remote_scp_path(local_path, true)
+    if deployment and deployment.upload_on_save == true then
+      M.upload_file(local_path, _finished)
+    else
+      _finished()
+    end
+  end
+
+  local ok, result = pcall(_upload)
+  if not ok then
+    _finished()
+    vim.schedule(function()
+      vim.notify("Error uploading file\n"..tostring(result), vim.log.levels.ERROR)
+    end)
+  end
+end
+
 -- upload the given file
 -- @param local_path string
 -- @param callback? function
@@ -257,12 +299,19 @@ function M.upload_file(local_path, callback)
   local remote_path, deployment = M.remote_scp_path(local_path)
   if remote_path == nil then
     if callback then
-      vim.schedule(callback)
+      callback()
     end
     return
   end
 
   build_command(deployment, { "scp", local_path, remote_path }, function(command)
+    if not command then
+      if callback then
+        vim.schedule(callback)
+      end
+      return
+    end
+
     local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
     local notification = vim.notify(local_short, vim.log.levels.INFO, {
       title = "Uploading file...",
@@ -285,6 +334,10 @@ function M.upload_file(local_path, callback)
         vim.list_extend(stderr, data)
       end,
       on_exit = function(_, code, _)
+        if callback then
+          vim.schedule(callback)
+        end
+
         if code == 0 then
           vim.notify(remote_path, vim.log.levels.INFO, {
             id = notification_id,
@@ -301,9 +354,6 @@ function M.upload_file(local_path, callback)
             replace = notification_id,
             icon = " ",
           })
-        end
-        if callback then
-          vim.schedule(callback)
         end
       end,
     })
@@ -324,6 +374,10 @@ function M.download_file(local_path)
   end
 
   build_command(deployment, { "scp", remote_path, local_path }, function(command)
+    if not command then
+      return
+    end
+
     local local_short = vim.fn.fnamemodify(local_path, ":~"):gsub(".*/", "")
     local notification = vim.notify(local_short, vim.log.levels.INFO, {
       title = "Downloading file...",
@@ -421,6 +475,10 @@ function M.sync_dir(dir, upload)
   end
 
   build_command(deployment, cmd, function(command)
+    if not command then
+      return
+    end
+
     local notification = vim.notify("rsync: " .. remote_path, vim.log.levels.INFO, {
       title = "Sync started...",
       icon = " ",
@@ -518,6 +576,10 @@ function M.show_dir_diff(dir)
   local lines = { " " .. table.concat(cmd, " "), normalize_local_path(dir), remote_path, "------" }
 
   build_command(deployment, cmd, function(command)
+    if not command then
+      return
+    end
+
     local notification = vim.notify("rsync -rlzi --dry-run --checksum --delete", vim.log.levels.INFO, {
       title = "Diff started...",
       icon = " ",


### PR DESCRIPTION
## Overview of Changes

This PR introduces a `BufWritePost` event handler bundled into the plugin which enables auto-upload on save for files mapped to deployments. The handler:
- Checks if a deployment/mapping exists for the saved file.
- Verifies if `upload_on_save` is enabled for that deployment/mapping and quietly returns if not.
- Uses a debouncing mechanism to prevent concurrent uploads of the same file, by adding callback support to the `upload_file` method.

## Case for the Feature

While auto-upload on save is a recognized use case, previous PRs have relied on plugin-level configuration. This PR takes a different approach by allowing `upload_on_save` to be set per deployment/mapping.

This is especially important for large monorepos or projects with multiple local:remote mappings, where upload behavior may need to vary between different parts of the project. By scoping this feature to individual mappings, users gain fine-grained control without imposing global behavior, making the plugin more flexible for real-world workflows.

IMHO this is a core quality-of-life feature which addresses the fact that the `upload_on_save` decision is not a global decision, but a project/host/mapping decision which should not be left to the user to implement on their own.

## Sample Deployment Config

```lua
-- .nvim/deployment.lua
return {
  ["example_name"] = {
    host = "myhost",
    username = "web", -- optional
    mappings = {
      {
        ["local"] = "live", -- path relative to project root
        ["remote"] = "/var/www/example.com", -- absolute path or relative to user home
      },
      {
        ["local"] = "test",
        ["remote"] = "/var/www/test.example.com",
      },
    },
    excludedPaths = { -- optional
      "live/src/", -- local path relative to project root
      "test/src/",
    },
    upload_on_save = true
  },
}
```
