### PR TITLE
docs: add example for folke/snacks.nvim explorer and allow DiffRemote command to accept args

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,20 @@ return {
             transfer_down = function(_, item)
               vim.cmd.TransferDownload(item.file)
             end,
+            transfer_diff = function(_, item)
+              if item.dir then
+                vim.cmd.TransferDirDiff(item.file)
+              else
+                vim.cmd.DiffRemote(item.file)
+              end
+            end,
           },
           win = {
             list = {
               keys = {
                 ['tu'] = 'transfer_up',
                 ['td'] = 'transfer_down',
+                ['tD'] = 'transfer_diff',
               }
             }
           }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ return {
   ["example_name"] = {
     host = "myhost",
     username = "web", -- optional
+    password = true, -- optional (string|true will prompt for password)
     mappings = {
       {
         ["local"] = "live", -- path relative to project root
@@ -150,6 +151,43 @@ require("which-key").add({
     icon = { color = "green", icon = "󰕒" },
   },
 })
+```
+
+## Snacks.explorer (with lazy.nvim)
+
+```lua
+return {
+  "coffebar/transfer.nvim",
+  lazy = true,
+  cmd = { "TransferInit", "DiffRemote", "TransferUpload", "TransferDownload", "TransferDirDiff", "TransferRepeat" },
+  opts = {},
+  dependencies = { 'folke/snacks.nvim' },
+  specs = {
+    {
+      'folke/snacks.nvim',
+      opts = {
+        picker = {
+          actions = {
+            transfer_up = function(_, item)
+              vim.cmd.TransferUpload(item.file)
+            end,
+            transfer_down = function(_, item)
+              vim.cmd.TransferDownload(item.file)
+            end,
+          },
+          win = {
+            list = {
+              keys = {
+                ['tu'] = 'transfer_up',
+                ['td'] = 'transfer_down',
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 ```
 
 ## Recommended to use with

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ return {
   ["example_name"] = {
     host = "myhost",
     username = "web", -- optional
-    password = true, -- optional (string|true will prompt for password)
     mappings = {
       {
         ["local"] = "live", -- path relative to project root

--- a/lua/transfer/commands.lua
+++ b/lua/transfer/commands.lua
@@ -53,8 +53,14 @@ M.setup = function()
   end, { nargs = 0 })
 
   -- DiffRemote - open a diff view with the remote file
-  vim.api.nvim_create_user_command("DiffRemote", function()
-    local local_path = vim.fn.expand("%:p")
+  vim.api.nvim_create_user_command("DiffRemote", function(opts)
+    local local_path
+    if opts ~= nil and opts.args then
+      local_path = opts.args
+    end
+    if local_path == nil or local_path == "" then
+      local_path = vim.fn.expand("%:p")
+    end
     local remote_path = require("transfer.transfer").remote_scp_path(local_path)
     if remote_path == nil then
       return
@@ -73,7 +79,7 @@ M.setup = function()
     end
 
     vim.api.nvim_command("silent! diffsplit " .. remote_path)
-  end, { nargs = 0 })
+  end, { nargs = "?" })
 
   -- TransferUpload - upload the given file or directory
   vim.api.nvim_create_user_command("TransferUpload", function(opts)


### PR DESCRIPTION
## Overview of Changes

- Updated `README.md` to show how to add keymaps for the `explorer` component in the `snacks.nvim` plugin.
- Enhanced the `DiffRemote` command to accept `args`, enabling file diffs to be triggered via keymaps (in addition to the existing support for folders).

```lua
return {
  "coffebar/transfer.nvim",
  lazy = true,
  cmd = { "TransferInit", "DiffRemote", "TransferUpload", "TransferDownload", "TransferDirDiff", "TransferRepeat" },
  opts = {},
  dependencies = { 'folke/snacks.nvim' },
  specs = {
    {
      'folke/snacks.nvim',
      opts = {
        picker = {
          actions = {
            transfer_up = function(_, item)
              vim.cmd.TransferUpload(item.file)
            end,
            transfer_down = function(_, item)
              vim.cmd.TransferDownload(item.file)
            end,
            transfer_diff = function(_, item)
              if item.dir then
                vim.cmd.TransferDirDiff(item.file)
              else
                vim.cmd.DiffRemote(item.file)
              end
            end,
          },
          win = {
            list = {
              keys = {
                ['tu'] = 'transfer_up',
                ['td'] = 'transfer_down',
                ['tD'] = 'transfer_diff',
              }
            }
          }
        }
      }
    }
  }
}
```